### PR TITLE
Bassel

### DIFF
--- a/app/controllers/members/omniauth_callbacks_controller.rb
+++ b/app/controllers/members/omniauth_callbacks_controller.rb
@@ -37,6 +37,6 @@ class Members::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def auth
-    @auth = request.env['omniauth.auth']
+    @auth ||= Rails.application.env_config['omniauth.auth'] || request.env['omniauth.auth']
   end
 end

--- a/app/controllers/sign_in_controller.rb
+++ b/app/controllers/sign_in_controller.rb
@@ -1,2 +1,18 @@
 class SignInController < ApplicationController
+  def index
+    @members = Member.all
+  end
+
+  def show
+  end
+
+  def new
+    @member = Member.new
+  end
+
+  def edit
+  end
+
+  def delete
+  end
 end

--- a/app/views/sign_in/_member.json.jbuilder
+++ b/app/views/sign_in/_member.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! member, :email, :full_name, :uid, :avatar_url, :is_admin, :created_at, :updated_at
+json.url member_url(member, format: :json)

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -47,10 +47,45 @@ var a=(this||self)._jsa||{};a._cfc=void 0;a._aeh=void 0;/*
 
 <!-- ################################################################################################### -->
 
+      <% if !member_signed_in? %>
         <%= link_to "Sign in with Google" , member_google_oauth2_omniauth_authorize_path, method:
           :post %>
+      <% end %>
           <br>
-          <%= link_to "Sign Out" , destroy_member_session_path %>
+        
+      <% if member_signed_in? %>
+      <!-- Show the profile -->
+
+        <%= image_tag("#{current_member.avatar_url}") %>
+        <h4><%= current_member.full_name %></h4>
+        <p> <%= current_member.email %> </p>
+
+        <%= link_to "Sign Out" , destroy_member_session_path %>
+
+        <% if current_member.is_admin?%>
+        <!-- Show all uesrs for promotions/deletions -->
+        <table>
+          <thead>
+            <tr>
+              <th>Username</th>
+              <th>Email</th>
+              <th>Is Admin?</th>
+              <th colspan="3"></th>
+            </tr>
+          </thead>
+
+          <tbody>
+          <% @members.each do |member| %>
+            <tr>
+              <td><%= member.full_name %></td>
+              <td><%= member.email %></td>
+              <td><%= member.is_admin%></td>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+        <% end %>
+      <% end %>
 
 <!-- ################################################################################################### -->
 

--- a/app/views/sign_in/index.json.jbuilder
+++ b/app/views/sign_in/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @members, partial: "members/member", as: :member

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,4 +57,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+  
+  ENV['GOOGLE_OAUTH_CLIENT_ID'] = '20270167427-jsjim7m6c9r763e9nrtt7mu9vsh3vl5j.apps.googleusercontent.com'
+  ENV['GOOGLE_OAUTH_CLIENT_SECRET'] = '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'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :members, controllers: {omniauth_callbacks: 'members/omniauth_callbacks'}
   devise_scope :member do
     get 'members/sign_in', to: 'sign_in#index', as: :new_member_session
-	  delete 'members/sign_out', to: 'devise/sessions#destroy', as: :destroy_member_session
+	get 'members/sign_out', to: 'devise/sessions#destroy', as: :destroy_member_session
   end
 
   #root :to => 'home#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,13 @@
 Rails.application.routes.draw do
+  # For OAuth
   devise_for :members, controllers: {omniauth_callbacks: 'members/omniauth_callbacks'}
   devise_scope :member do
     get 'members/sign_in', to: 'sign_in#index', as: :new_member_session
 	get 'members/sign_out', to: 'devise/sessions#destroy', as: :destroy_member_session
   end
+  
+  # For OAuth Testing
+  post '/members/auth/google_oauth2'
 
   #root :to => 'home#index'
 

--- a/spec/controllers/oauth_spec.rb
+++ b/spec/controllers/oauth_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+# From https://stackoverflow.com/questions/52171212/using-minitest-when-trying-to-test-omniauth-google-oauth2-gem-i-keep-getting
+
+RSpec.describe 'Authentication test', type: :feature do
+  before do
+    OmniAuth.config.test_mode = true
+    Rails.application.env_config['devise.mapping'] = Devise.mappings[:user]
+  end
+  
+  teardown do
+    OmniAuth.config.test_mode = false
+  end
+  
+  scenario 'Signs in as Admin'  do
+    Rails.application.env_config['omniauth.auth']  = google_oauth2_mock_admin
+    visit new_member_session_path
+    click_link 'Sign in with Google'
+	expect(page).to have_content('Successfully authenticated')
+  end
+  
+  scenario 'Attempt to sign in without regex match (SHOULD FAIL)' do
+    Rails.application.env_config['omniauth.auth']  = google_oauth2_mock_fail
+    visit new_member_session_path
+    click_link 'Sign in with Google'
+	expect(page).to have_content('Successfully authenticated')
+  end
+  
+  scenario 'Attempt to sign in with regex match' do
+    Rails.application.env_config['omniauth.auth']  = google_oauth2_mock_user
+    visit new_member_session_path
+    click_link 'Sign in with Google'
+	expect(page).to have_content('Successfully authenticated')
+  end
+  
+  private
+
+  def google_oauth2_mock_admin
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
+      provider: 'google_oauth2',
+      uid: '1',
+      info: { 
+        email: 'tamucadetwebsite@gmail.com',
+        full_name: 'CADET TAMU',
+      },
+      credentials: {
+        token: 'token here',
+        refresh_token: 'token here',
+        expires_at: DateTime.now
+      }
+    })
+  end
+  
+  def google_oauth2_mock_fail
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
+      provider: 'google_oauth2',
+      uid: '12345678910',
+      info: { 
+        email: 'not_allowed@gmail.com',
+        full_name: 'Bassel Toubbeh',
+      },
+      credentials: {
+        token: 'another token',
+        refresh_token: 'another token',
+        expires_at: DateTime.now
+      }
+    })
+  end
+  
+  def google_oauth2_mock_user
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
+      provider: 'google_oauth2',
+      uid: '12345678910',
+      info: { 
+        email: 'member@tamu.edu',
+        full_name: 'Ryan Pickett',
+      },
+      credentials: {
+        token: 'thirdtoken',
+        refresh_token: 'thirdtoken',
+        expires_at: DateTime.now
+      }
+    })
+  end
+end


### PR DESCRIPTION
Acceptance Criteria - Nobody can sign in without being signed out or vice versa first. Members can see their information when logged in. People should only log in with Texas A&M Accounts or with the main email.

Definition of Done - Users have a profile page. Admins can see a list of all members. The system fails to sign unauthorized people into the website, giving a warning. The system successfully signs authorized people into the website with a flash too.

Coding Standard - Proper indentation, clear and concise variable names, usage of apostrophes instead of quotation marks.

